### PR TITLE
TypeError: can't compare offset-naive and offset-aware datetimes While cheching account is expred 

### DIFF
--- a/account/utils.py
+++ b/account/utils.py
@@ -131,7 +131,7 @@ def check_password_expired(user):
     except PasswordHistory.DoesNotExist:
         return False
 
-    now = datetime.datetime.now(tz=pytz.UTC)
+    now = datetime.datetime.now()
     expiration = latest.timestamp + datetime.timedelta(seconds=expiry)
 
     if expiration < now:


### PR DESCRIPTION
File "/home/ge-39/projects/python/django/sesio/env/lib/python3.6/site-packages/django/core/handlers/exception.py", line 47, in inner
response = get_response(request)
File "/home/ge-39/projects/python/django/sesio/env/lib/python3.6/site-packages/django/utils/deprecation.py", line 113, in call
response = self.process_request(request)
File "/home/ge-39/projects/python/django/sesio/env/lib/python3.6/site-packages/account/middleware.py", line 75, in process_request
if check_password_expired(request.user):
File "/home/ge-39/projects/python/django/sesio/env/lib/python3.6/site-packages/account/utils.py", line 137, in check_password_expired
if expiration < now:
TypeError: can't compare offset-naive and offset-aware datetimes